### PR TITLE
set up secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,15 @@
+name: Publish package to the Maven Central Repository
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - id: install-secret-key
+        name: Install gpg secret key
+        run: |
+          # Install gpg secret key
+          cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
+          # Verify gpg secret key
+          gpg --list-secret-keys --keyid-format LONG

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>normalizer</artifactId>
     <name>Phonenumber Normalizer</name>
     <description>Library to work with phonenumbers, especially to fix googles PhoneLib ignoring German Landline specifics.</description>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <licenses>
         <license>


### PR DESCRIPTION
Preparing Maven Central release: secrets have been added to repository settings and now a workflow is added which uses them (see https://gist.github.com/sualeh/ae78dc16123899d7942bc38baba5203c until step 3). By this step we should see that gpg stuff is stop correctly.