### PR TITLE
Start Snapshot 1.1.16 after release 1.1.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>normalizer</artifactId>
     <name>Phonenumber Normalizer</name>
     <description>Library to work with phonenumbers, especially to fix googles PhoneLib ignoring German Landline specifics.</description>
-    <version>1.1.15</version>
+    <version>1.1.16-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/telekom/phonenumber-normalizer</url>
 


### PR DESCRIPTION
Start Snapshot 1.1.16 after release 1.1.15 (overjumping 1.1.14 which is wrongly the tag on github for 1.1.15)