### PR TITLE
Upgrading Dependencies 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '17'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/REPORTED_ISSUES.md
+++ b/REPORTED_ISSUES.md
@@ -15,7 +15,7 @@ This issue has been resolved.
 
 ### 2021-03-25 - [Germany (DE, +49): 116xxx Short Number valid vs. assigned](https://issuetracker.google.com/issues/183669955)
 
-This issue pertains to the EU-wide special social number short code definition. Although the regulation clearly defines a range, PhoneLib is not validating against that range, but against a list of currently assigned/operated numbers. At least for the German number space, as mentioned in the initial issue discussion (see first one above), the library is only partly or even completely checking the whole range in other EU number spaces.
+This issue pertains to the EU-wide special social number short code definition. Although the regulation clearly defines a range, LibPhoneNumber is not validating against that range, but against a list of currently assigned/operated numbers. At least for the German number space, as mentioned in the initial issue discussion (see first one above), the library is only partly or even completely checking the whole range in other EU number spaces.
 
 On the one hand, the [FAQ](https://github.com/google/libphonenumber/blob/master/FAQ.md#what_is_valid)(https://github.com/google/libphonenumber/blob/master/FAQ.md) states that “valid” does not mean “numbers are currently assigned to a specific user and reachable.”
 On the other hand, it states that “a valid number range is one from which numbers can be freely assigned by carriers to users,” which is not the case for EU-wide numbers that require special clearance.
@@ -25,7 +25,7 @@ While it seems that the last point is the argument for rejecting the issue (whic
 ## Internal Implementation
 
 After a long discussion and closing the issues as stated above, we decided to implement a minimal fix for normalizing German Phonenumbers for our internal use, to support the phoning capability of Deutsche Telekom Smart Speaker.
-We also set up [test cases to verify if PhoneLib behavior changes to correctly normalize the currently failing cases](https://github.com/telekom/phonenumber-normalizer/blob/main/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberUtilTest.groovy), so that our implementation would become unnecessary.
+We also set up [test cases to verify if LibPhoneNumber behavior changes to correctly normalize the currently failing cases](https://github.com/telekom/phonenumber-normalizer/blob/main/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberUtilTest.groovy), so that our implementation would become unnecessary.
 
 We also discovered, during its development, that the geolocation method uses BenetzA given labels, which include abbreviations.
 [For a smart speaker, we needed a “speakable” label - so we created the following issue and added our own list to our interim solution](https://github.com/telekom/phonenumber-normalizer/blob/main/src/main/resources/arealabels/nationallabels/de.json).

--- a/UPDATE_FOR_NEW_PHONELIB.md
+++ b/UPDATE_FOR_NEW_PHONELIB.md
@@ -1,31 +1,22 @@
-# How to adapt to a new Version of PhoneLib
+# How to adapt to a new Version of Google's LibPhoneNumber
 
-If Google updates its [PhoneLib](https://github.com/google/libphonenumber), this project should be updated to use that new version. This file is a step by step instruction how to do this:
+If Google updates its [LibPhoneNumber](https://github.com/google/libphonenumber), this project should be updated to use that new version. This file is a step by step instruction how to do this:
 
 1. Create a new local branch - best name it ```phonelib/X_YY_ZZ``` so it is easily seen that this branch is just an update for the version X.YY.ZZ, without any new features.
 
-2. Update [pom.xml](pom.xml) to use the new phonelib version:
+2. Update [pom.xml](pom.xml) to use the new LibPhoneNumber version in the properties section:
    ```
-   <dependency>
-     <groupId>com.googlecode.libphonenumber</groupId>
-     <artifactId>libphonenumber</artifactId>
-     <version>X.YY.ZZ</version>
-   </dependency>
+        <libphonenumber.version>X.YY.ZZ</libphonenumber.version>
    ```
    
 3. Check on Maven Central ```https://central.sonatype.com/artifact/com.googlecode.libphonenumber/libphonenumber/X.YY.ZZ/dependents``` the version number for ```geocoder``` (referred as A.BBB).
 
-4. Update [pom.xml](pom.xml) to use the new geocoder version in testing:
+4. Update [pom.xml](pom.xml) to use the new geocoder version in testing in the properties section:
    ```
-        <dependency>
-            <groupId>com.googlecode.libphonenumber</groupId>
-            <artifactId>geocoder</artifactId>
-            <version>A.BBB</version>
-            <scope>test</scope>
-        </dependency>
+        <geocoder.version>A.BBB</geocoder.version>
    ```
    
-5. Run all unit test and check log messages if Phonelib still is not correctly:
+5. Run all unit test and check log messages if LibPhoneNumber still is not correctly:
    a) normalizing specific number -> this project is still necessary
    b) labeling specific numbers -> own area labels for DE still necessary
    if there are corrections or additional mismatches listed - name those in the commit message and update tests.
@@ -34,7 +25,7 @@ If Google updates its [PhoneLib](https://github.com/google/libphonenumber), this
 
 7. Commit & Push the Snapshot with a message like:
    ```
-   Use PhoneLib X.YY.ZZ and prepare release
+   Use LibPhoneNumber X.YY.ZZ and prepare release
    ```
    
 8. Go to Github and create a pull request for the branch.
@@ -43,7 +34,7 @@ If Google updates its [PhoneLib](https://github.com/google/libphonenumber), this
 
 10. After merge has finished, draft a new Release. Use as tag the ```v```+ the version number of the pom, where you removed ```-SNAPSHOT```. As Release title use  ```PhoneLib X.YY.ZZ``` and add a message like:
     ```
-    Use the latest PhoneLib version from four days ago.
+    Use the latest LibPhoneNumber version from four days ago.
     ```
     Keep the flag "Set as the latest release" and press Publish release.
 
@@ -62,4 +53,4 @@ If Google updates its [PhoneLib](https://github.com/google/libphonenumber), this
 
 16. Delete the branch ```phonelib/X_YY_ZZ```.
 
-Congratulation! You have updated the project to the [current PhoneLib version](https://central.sonatype.com/artifact/com.googlecode.libphonenumber/libphonenumber).
+Congratulation! You have updated the project to the [current LibPhoneNumber version](https://central.sonatype.com/artifact/com.googlecode.libphonenumber/libphonenumber).

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <com.fasterxml.jackson.core.version>2.16.1</com.fasterxml.jackson.core.version>
         <org.codehaus.gmavenplus.version>1.11.0</org.codehaus.gmavenplus.version>
         <org.springframework.version>6.1.3</org.springframework.version>
+        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <!-- JaCoCo & SonarQube -->
         <rootDir>${project.basedir}</rootDir>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -223,7 +224,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>${maven.compiler.plugin.version}</version>
             </plugin>
 
             <plugin>
@@ -349,9 +350,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>${maven.compiler.plugin.version}</version>
                     <configuration>
-                        <release>${java.version}</release>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
                         <annotationProcessorPaths>
                             <!-- be aware of the order in regards to -->
                             <!-- https://github.com/rzwitserloot/lombok/issues/1538 -->

--- a/pom.xml
+++ b/pom.xml
@@ -72,13 +72,20 @@
         <geocoder.version>2.223</geocoder.version>
         <!-- Used Versions of other dependencies: -->
         <java.version>17</java.version>
-        <mapstruct.version>1.3.0.Final</mapstruct.version>
-        <lombok.version>1.18.28</lombok.version>
-        <surefire.plugin.version>2.22.2</surefire.plugin.version>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <lombok.version>1.18.30</lombok.version>
+        <surefire.plugin.version>2.22.2</surefire.plugin.version> <!-- not yet updated because version 3.x has vulnerability-->
         <com.fasterxml.jackson.core.version>2.16.1</com.fasterxml.jackson.core.version>
         <org.codehaus.gmavenplus.version>1.11.0</org.codehaus.gmavenplus.version>
         <org.springframework.version>6.1.3</org.springframework.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
+        <org.apache.commons.version>3.14.0</org.apache.commons.version>
+        <io.swagger.verion>1.6.13</io.swagger.verion>
+        <org.slf4j.version>2.0.11</org.slf4j.version>
+        <jakarta.annotation.version>3.0.0-M1</jakarta.annotation.version>
+        <org.apache.groovy.version>4.0.18</org.apache.groovy.version>
+        <org.junit.platform.version>1.10.1</org.junit.platform.version>
+        <org.spockframework.version>2.4-M1-groovy-4.0</org.spockframework.version>
         <!-- JaCoCo & SonarQube -->
         <rootDir>${project.basedir}</rootDir>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -112,12 +119,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
+            <version>${org.apache.commons.version}</version>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>1.6.13</version>
+            <version>${io.swagger.verion}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -137,12 +144,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.11</version>
+            <version>${org.slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>3.0.0-M1</version>
+            <version>${jakarta.annotation.version}</version>
         </dependency>
         <!-- For Testing only -->
         <dependency>
@@ -154,20 +161,20 @@
         <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>4.0.18</version>
+            <version>${org.apache.groovy.version}</version>
             <scope>test</scope>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.10.1</version>
+            <version>${org.junit.platform.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>2.4-M1-groovy-4.0</version>
+            <version>${org.spockframework.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
     <groupId>de.telekom.phonenumber</groupId>
     <artifactId>normalizer</artifactId>
-    <name>Phonenumber Normalizer</name>
-    <description>Library to work with phonenumbers, especially to fix googles PhoneLib ignoring German Landline specifics.</description>
+    <name>Phone Number Normalizer</name>
+    <description>Library to wrap around Google's LibPhoneNumber library, to fix the ignoring of German Landline specifics when normalizing phone numbers.</description>
     <version>1.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/telekom/phonenumber-normalizer</url>
@@ -67,8 +67,17 @@
         <rootDir>${project.basedir}/..</rootDir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <!-- Used Versions of Google's libphone project -->
+        <libphonenumber.version>8.13.29</libphonenumber.version>
+        <geocoder.version>2.223</geocoder.version>
+        <!-- Used Versions of other dependencies: -->
+        <java.version>17</java.version>
         <mapstruct.version>1.3.0.Final</mapstruct.version>
         <lombok.version>1.18.28</lombok.version>
+        <surefire.plugin.version>2.22.2</surefire.plugin.version>
+        <com.fasterxml.jackson.core.version>2.16.1</com.fasterxml.jackson.core.version>
+        <org.codehaus.gmavenplus.version>1.11.0</org.codehaus.gmavenplus.version>
+        <org.springframework.version>6.1.3</org.springframework.version>
         <!-- JaCoCo & SonarQube -->
         <rootDir>${project.basedir}</rootDir>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -77,7 +86,6 @@
         <sonar.coverage.jacoco.xmlReportPaths>
             ${project.basedir}/../${aggregate.report.dir}
         </sonar.coverage.jacoco.xmlReportPaths>
-        <surefire.plugin.version>2.22.2</surefire.plugin.version>
     </properties>
 
     <dependencies>
@@ -86,7 +94,7 @@
         <dependency>
             <groupId>com.googlecode.libphonenumber</groupId>
             <artifactId>libphonenumber</artifactId>
-            <version>8.13.29</version>
+            <version>${libphonenumber.version}</version>
         </dependency>
 
         <dependency>
@@ -95,54 +103,51 @@
             <scope>provided</scope> <!-- must be provided, see docs -->
             <version>${lombok.version}</version>
         </dependency>
-        <!--
-        TODO: need to upgrade spring context to 6.x
-        -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>5.3.31</version>
+            <version>${org.springframework.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>1.6.11</version>
+            <version>1.6.13</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.15.2</version>
+            <version>${com.fasterxml.jackson.core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.15.2</version>
+            <version>${com.fasterxml.jackson.core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
+            <version>${com.fasterxml.jackson.core.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.11</version>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>3.0.0-M1</version>
         </dependency>
         <!-- For Testing only -->
         <dependency>
             <groupId>com.googlecode.libphonenumber</groupId>
             <artifactId>geocoder</artifactId>
-            <version>2.223</version>
+            <version>${geocoder.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -167,7 +172,7 @@
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>2.3-groovy-3.0</version>
+            <version>2.4-M1-groovy-3.0</version>
             <scope>test</scope>
         </dependency>
         <!-- Replace Version 7.5 which has https://devhub.checkmarx.com/cve-details/CVE-2022-4065/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea&utm_term=maven -->
@@ -236,7 +241,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.11.0</version>
+                <version>${org.codehaus.gmavenplus.version}</version>
             </plugin>
 
             <plugin>
@@ -346,8 +351,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.0</version>
                     <configuration>
-                        <release>11</release>
-
+                        <release>${java.version}</release>
                         <annotationProcessorPaths>
                             <!-- be aware of the order in regards to -->
                             <!-- https://github.com/rzwitserloot/lombok/issues/1538 -->
@@ -397,7 +401,7 @@
                 <plugin>
                     <groupId>org.codehaus.gmavenplus</groupId>
                     <artifactId>gmavenplus-plugin</artifactId>
-                    <version>1.11.0</version>
+                    <version>${org.codehaus.gmavenplus.version}</version>
                     <executions>
                         <execution>
                             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -152,45 +152,24 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>3.0.17</version>
+            <version>4.0.18</version>
             <scope>test</scope>
             <type>pom</type>
-            <exclusions>
-                <exclusion>
-                    <!-- Used Version 7.5 has https://devhub.checkmarx.com/cve-details/CVE-2022-4065/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea&utm_term=maven -->
-                    <groupId>org.testng</groupId>
-                    <artifactId>testng</artifactId>
-                </exclusion>
-                <exclusion>
-                    <!--User Version 3.5.1 has https://devhub.checkmarx.com/cve-details/CVE-2007-2379/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea -->
-                    <groupId>org.webjars</groupId>
-                    <artifactId>jquery</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.10.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>2.4-M1-groovy-3.0</version>
+            <version>2.4-M1-groovy-4.0</version>
             <scope>test</scope>
         </dependency>
-        <!-- Replace Version 7.5 which has https://devhub.checkmarx.com/cve-details/CVE-2022-4065/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea&utm_term=maven -->
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>7.8.0</version>
-            <scope>test</scope>
-        </dependency>
-        <!--Replaces Version 3.5.1 which has https://devhub.checkmarx.com/cve-details/CVE-2007-2379/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea -->
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>jquery</artifactId>
-            <version>3.6.4</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberAreaLabelImpl.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberAreaLabelImpl.java
@@ -32,7 +32,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.stereotype.Component;
 
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.util.*;
 import java.util.regex.Pattern;

--- a/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberNormalizer.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberNormalizer.java
@@ -34,7 +34,7 @@ public interface PhoneNumberNormalizer {
     void setFallbackRegionCode(String fallBackRegionCode);
 
     /**
-     * Normalizes the number using PhoneLib with some additions to compensate.
+     * Normalizes the number using LibPhoneNumber with some additions to compensate.
      * <p>
      * Preferable to {@link PhoneNumberNormalizer#normalizePhoneNumber(String, String)}, because default NDC can be provided, so that more compensation for generating a valid E164 can be done.
      * </p>
@@ -47,7 +47,7 @@ public interface PhoneNumberNormalizer {
     String normalizePhoneNumber(String number, DeviceContext deviceContext);
 
     /**
-     * Normalizes the number using PhoneLib with some additions to compensate.
+     * Normalizes the number using LibPhoneNumber with some additions to compensate.
      * <p>
      * Not as powerful as {@link PhoneNumberNormalizer#normalizePhoneNumber(String, DeviceContext)}, because no default NDC can be set.
      * </p>

--- a/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberNormalizerImpl.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberNormalizerImpl.java
@@ -71,14 +71,14 @@ public class PhoneNumberNormalizerImpl implements PhoneNumberNormalizer {
     }
 
     /**
-     * Uses wrapper of PhoneLib to identify if special rules apply for normalization.<br/>
+     * Uses wrapper of LibPhoneNumber to identify if special rules apply for normalization.<br/>
      * Using device context for enriching the number make it normalizable to E164 format if NDC is optional in the used number plan, but not used in the phone number to be normalized.
-     * @param wrapper instanced wrapper of PhoneLib
+     * @param wrapper instanced wrapper of LibPhoneNumber
      * @param deviceContext information like CC, NDC and {@link de.telekom.phonenumbernormalizer.dto.DeviceContextLineType} from which the number is dialled
      * @return E164 formatted phone number or dialable version of it or null
      */
     private String normalize(PhoneLibWrapper wrapper, DeviceContext deviceContext) {
-        // international prefix has been added by PhoneLib even if it's not valid in the number plan.
+        // international prefix has been added by LibPhoneNumber even if it's not valid in the number plan.
         if (wrapper == null) {
             LOGGER.debug("PhoneLipWrapper was not initialized");
             return null;

--- a/src/main/java/de/telekom/phonenumbernormalizer/numberplans/NumberPlan.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/numberplans/NumberPlan.java
@@ -29,7 +29,7 @@ import java.util.Comparator;
  * This class provides basic logic to check a given number against a simple set of rules to identify if it is short numbers, which does not need normalization.
  * It also needs to provide its country calling code, to specify where the rules apply.
  * <p>
- * PhoneLib already provide a ShortNumbers, but for EU wide 116xxx range only a few countries are configured to support the range. 
+ * LibPhoneNumber already provide a ShortNumbers, but for EU wide 116xxx range only a few countries are configured to support the range.
  * For Germany only currently assigned numbers are configured which is in contrast to Googles definition of checks, 
  * but nevertheless the <a href="https://issuetracker.google.com/u/1/issues/183669955">corresponding Issues</a> has been rejected.
  * </p><p>

--- a/src/main/java/de/telekom/phonenumbernormalizer/numberplans/PhoneLibWrapper.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/numberplans/PhoneLibWrapper.java
@@ -26,11 +26,11 @@ import java.lang.reflect.Method;
 import java.util.Objects;
 
 /**
- * Wrapper around the PhoneLib library from Google
+ * Wrapper around the LibPhoneNumber library from Google
  * <p>
  * Using reflection to access internal information to know if a region has a nation prefix &amp; which one it is.
  * </p><p>
- * Providing own NumberPlans logic as an alternative to PhoneLib ShortNumber.
+ * Providing own NumberPlans logic as an alternative to LibPhoneNumber ShortNumber.
  * </p>
  * @see NumberPlan
  */
@@ -48,7 +48,7 @@ public class PhoneLibWrapper {
     String dialableNumber;
 
     /**
-     * The given number normalized with PhoneLib, risking we get a incorrect normalization
+     * The given number normalized with LibPhoneNumber, risking we get an incorrect normalization
      *
      * @see PhoneLibWrapper#PhoneLibWrapper(String, String)
      * @see PhoneLibWrapper#isNormalizingTried()
@@ -65,24 +65,24 @@ public class PhoneLibWrapper {
     String regionCode;
 
     /**
-     * The number plan metadata which PhoneLib is using for the given region code.
+     * The number plan metadata which LibPhoneNumber is using for the given region code.
      *
      * @see PhoneLibWrapper#PhoneLibWrapper(String, String)
      */
     Phonemetadata.PhoneMetadata metadata;
 
     /**
-     * An instance of the PhoneLib short number utility.
+     * An instance of the LibPhoneNumber short number utility.
      */
     private static final ShortNumberInfo shortNumberUtil = ShortNumberInfo.getInstance();
 
     /**
-     * An instance of the PhoneLib number utility.
+     * An instance of the LibPhoneNumber number utility.
      */
     private static final PhoneNumberUtil phoneUtil = PhoneNumberUtil.getInstance();
 
     /**
-     * Storing if PhoneLib has been used to parse the given number into semiNormalizedNumber.
+     * Storing if LibPhoneNumber has been used to parse the given number into semiNormalizedNumber.
      *
      * @see PhoneLibWrapper#PhoneLibWrapper(String, String)
      * @see PhoneLibWrapper#semiNormalizedNumber
@@ -116,7 +116,7 @@ public class PhoneLibWrapper {
     }
 
     /**
-     * If PhoneLib has been used to parse the given number into semiNormalizedNumber.
+     * If LibPhoneNumber has been used to parse the given number into semiNormalizedNumber.
      *
      * @return {@link PhoneLibWrapper#isNormalizingTried}
      *
@@ -127,11 +127,11 @@ public class PhoneLibWrapper {
     }
 
     /**
-     * Using PhoneLib short number utility if it identifies the given number as a short number, which would not need a NAC.
+     * Using LibPhoneNumber short number utility if it identifies the given number as a short number, which would not need a NAC.
      * <p>
      * This is a fallback for {@link PhoneLibWrapper#isShortNumber(NumberPlan)}, when we do not have an own number plan information.
      * </p>
-     * @return if PhoneLib identifies given number as a short number
+     * @return if LibPhoneNumber identifies given number as a short number
      *
      * @see PhoneLibWrapper#PhoneLibWrapper(String, String)
      * @see PhoneLibWrapper#isShortNumber(NumberPlan)
@@ -146,7 +146,7 @@ public class PhoneLibWrapper {
      * If no number plan is given, {@link PhoneLibWrapper#isShortNumber} is used as fallback.
      * </p>
      * @param numberplan the number plan we identified to be used for a check
-     * @return if number plan or as fallback PhoneLib identifies given number as a short number
+     * @return if number plan or as fallback LibPhoneNumber identifies given number as a short number
      *
      * @see PhoneLibWrapper#PhoneLibWrapper(String, String)
      */
@@ -174,7 +174,7 @@ public class PhoneLibWrapper {
     }
 
     /**
-     * Using PhoneLib to get a E164 formatted representation of the given number
+     * Using LibPhoneNumber to get a E164 formatted representation of the given number
      * <p>
      * This is a straight invocation, so no compensation of some inaccuracy is done here.
      * </p>
@@ -232,7 +232,7 @@ public class PhoneLibWrapper {
     }
 
     /**
-     * Use PhoneLib to parse a number for a regions code. If any exception occurs, they are logged and null is returned.
+     * Use LibPhoneNumber to parse a number for a regions code. If any exception occurs, they are logged and null is returned.
      * @param number the phone number to be parsed
      * @param regionCode ISO2 code for the regions number plan used for parsing the number
      * @return either the parsed {@link Phonenumber.PhoneNumber} or null
@@ -249,7 +249,7 @@ public class PhoneLibWrapper {
     }
 
     /**
-     * The National Access Code used before the National Destination Code in the given region from PhoneLib
+     * The National Access Code used before the National Destination Code in the given region from LibPhoneNumber
      * @return NAC of given {@link PhoneLibWrapper#regionCode}
      */
     public String getNationalAccessCode() {
@@ -260,7 +260,7 @@ public class PhoneLibWrapper {
     }
 
     /**
-     * From PhoneLib, if a National Access Code is used before the National Destination Code in the given region
+     * From LibPhoneNumber, if a National Access Code is used before the National Destination Code in the given region
      * @return if given {@link PhoneLibWrapper#regionCode} is using NAC
      */
     public boolean hasRegionNationalAccessCode() {
@@ -287,7 +287,7 @@ public class PhoneLibWrapper {
     }
 
     /**
-     * Using PhoneLib to get the national number from the given number
+     * Using LibPhoneNumber to get the national number from the given number
      *
      * @return national number without NAC, but any other leading zero.
      *
@@ -300,10 +300,10 @@ public class PhoneLibWrapper {
     }
 
     /**
-     * Using PhoneLib to get the national number from a parsed phone number with leading zeros, if those are not representing a National Access Code.
+     * Using LibPhoneNumber to get the national number from a parsed phone number with leading zeros, if those are not representing a National Access Code.
      * <p/>
-     * This is necessary, because PhoneLib is storing the national number as a long, so leading "0" Digits as part of it are stored in other attributes.
-     * @param phoneNumber A PhoneLib parsed phone number
+     * This is necessary, because LibPhoneNumber is storing the national number as a long, so leading "0" Digits as part of it are stored in other attributes.
+     * @param phoneNumber A LibPhoneNumber parsed phone number
      * @return national number part without NationalPrefix (aka NAC) but any other leading zero.
      */
     private static String nationalPhoneNumberWithoutNationalPrefix(Phonenumber.PhoneNumber phoneNumber) {
@@ -320,7 +320,7 @@ public class PhoneLibWrapper {
     }
 
     /**
-     * Using PhoneLib to get the Country Calling Code for a region code
+     * Using LibPhoneNumber to get the Country Calling Code for a region code
      * <p>
      * e.g. "DE" is "49"
      * </p>
@@ -332,7 +332,7 @@ public class PhoneLibWrapper {
     }
 
     /**
-     * Using PhoneLib to get the region code for a Country Calling Code
+     * Using LibPhoneNumber to get the region code for a Country Calling Code
      * <p>
      * e.g. "49" is "DE"
      * </p>

--- a/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberOfflineGeocoderTest.groovy
+++ b/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberOfflineGeocoderTest.groovy
@@ -48,13 +48,13 @@ class PhoneNumberOfflineGeocoderTest extends Specification {
         then: "is number expected: $expectedResult"
         if ((result != expectedResult) && (result2 != expectedResult)){
             if (expectingFail) {
-                logger.info("PhoneLib is still not correctly labeling $areacode to $expectedResult by giving $result")
+                logger.info("LibPhoneNumber is still not correctly labeling $areacode to $expectedResult by giving $result")
             } else {
-                logger.warning("PhoneLib is suddenly not correctly labeling $areacode to $expectedResult by giving $result")
+                logger.warning("LibPhoneNumber is suddenly not correctly labeling $areacode to $expectedResult by giving $result")
             }
         } else {
             if (expectingFail) {
-                logger.info("!!! PhoneLib is now correctly labeling $areacode to $expectedResult !!!")
+                logger.info("!!! LibPhoneNumber is now correctly labeling $areacode to $expectedResult !!!")
             }
         }
 
@@ -1586,7 +1586,7 @@ class PhoneNumberOfflineGeocoderTest extends Specification {
         "38326"  | "Grimmen"                                | false
         "38327"  | "Elmenhorst Vorpommern"                  | true   // see https://issuetracker.google.com/issues/183383466
         "38328"  | "Miltzow"                                | false
-        "38331"  | "Rakow Vorpommern"                       | true   // Both ITU and BNetzA "Rakow Vorpom", which is short form of "Vorpommern", it is included in PhoneLibe data, but Geocoder does not delivers it.
+        "38331"  | "Rakow Vorpommern"                       | true   // Both ITU and BNetzA "Rakow Vorpom", which is short form of "Vorpommern", it is included in LibPhoneNumber data, but Geocoder does not delivers it.
         "38332"  | "Gross Bisdorf"                          | false
         "38333"  | "Horst bei Grimmen"                      | false
         "38334"  | "Grammendorf"                            | false
@@ -1612,7 +1612,7 @@ class PhoneNumberOfflineGeocoderTest extends Specification {
         "38391"  | "Altenkirchen Rügen"                     | false
         "38392"  | "Sassnitz"                               | false
         "38393"  | "Binz Ostseebad"                         | false
-        "3841"   | "Wismar Mecklenburg"                     | true   // TODO: ITU "Wismar" only, but BNetzA "Wismar Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
+        "3841"   | "Wismar Mecklenburg"                     | true   // TODO: ITU "Wismar" only, but BNetzA "Wismar Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
         "38422"  | "Neukloster"                             | false
         "38423"  | "Bad Kleinen"                            | false
         "38424"  | "Bobitz"                                 | false
@@ -1634,7 +1634,7 @@ class PhoneNumberOfflineGeocoderTest extends Specification {
         "38458"  | "Zehna"                                  | false
         "38459"  | "Laage"                                  | false
         "38461"  | "Bützow"                                 | false
-        "38462"  | "Baumgarten Mecklenburg"                 | true   // TODO: ITU "Baumgarten" only, but BNetzA "Baumgarten Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
+        "38462"  | "Baumgarten Mecklenburg"                 | true   // TODO: ITU "Baumgarten" only, but BNetzA "Baumgarten Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
         "38464"  | "Bernitt"                                | false
         "38466"  | "Jürgenshagen"                           | false
         "3847"   | "Sternberg"                              | false
@@ -1645,7 +1645,7 @@ class PhoneNumberOfflineGeocoderTest extends Specification {
         "38485"  | "Dabel"                                  | false
         "38486"  | "Gustävel"                               | false
         "38488"  | "Demen"                                  | false
-        "385"    | "Schwerin Mecklenburg"                   | true   // TODO: ITU "Schwerin" only, but BNetzA "Schwerin Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
+        "385"    | "Schwerin Mecklenburg"                   | true   // TODO: ITU "Schwerin" only, but BNetzA "Schwerin Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
         "3860"   | "Raben Steinfeld"                        | false
         "3861"   | "Plate"                                  | false
         "3863"   | "Crivitz"                                | false
@@ -1669,17 +1669,17 @@ class PhoneNumberOfflineGeocoderTest extends Specification {
         "38732"  | "Gallin bei Lübz"                        | false
         "38733"  | "Karbow Vietlübbe"                       | false
         "38735"  | "Plau am See"                            | false
-        "38736"  | "Goldberg Mecklenburg"                   | true   // TODO: ITU "Goldberg" only, but BNetzA "Goldberg Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
+        "38736"  | "Goldberg Mecklenburg"                   | true   // TODO: ITU "Goldberg" only, but BNetzA "Goldberg Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
         "38737"  | "Ganzlin"                                | false
         "38738"  | "Karow bei Lübz"                         | false
-        "3874"   | "Ludwigslust Mecklenburg"                | true   // TODO: ITU "Ludwigslust" only, but BNetzA "Ludwigslust Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
+        "3874"   | "Ludwigslust Mecklenburg"                | true   // TODO: ITU "Ludwigslust" only, but BNetzA "Ludwigslust Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
         "38750"  | "Malliss"                                | false
         "38751"  | "Picher"                                 | false
         "38752"  | "Zierzow bei Ludwigslust"                | false
         "38753"  | "Wöbbelin"                               | false
         "38754"  | "Leussow bei Ludwigslust"                | false
         "38755"  | "Eldena"                                 | false
-        "38756"  | "Grabow Mecklenburg"                     | true   // TODO: ITU "Grabow" only, but BNetzA "Grabow Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
+        "38756"  | "Grabow Mecklenburg"                     | true   // TODO: ITU "Grabow" only, but BNetzA "Grabow Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
         "38757"  | "Neustadt Glewe"                         | false
         "38758"  | "Dömitz"                                 | false
         "38759"  | "Tewswoos"                               | false
@@ -1701,14 +1701,14 @@ class PhoneNumberOfflineGeocoderTest extends Specification {
         "38796"  | "Viesecke"                               | false
         "38797"  | "Karstädt Kreis Prignitz"                | false
         "3881"   | "Grevesmühlen"                           | false
-        "38821"  | "Lüdersdorf Mecklenburg"                 | true   // TODO: ITU "Lüdersdorf" only, but BNetzA "Lüdersdorf Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
+        "38821"  | "Lüdersdorf Mecklenburg"                 | true   // TODO: ITU "Lüdersdorf" only, but BNetzA "Lüdersdorf Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
         "38822"  | "Diedrichshagen bei Grevesmühlen"        | false
         "38823"  | "Selmsdorf"                              | false
         "38824"  | "Mallentin"                              | false
         "38825"  | "Klütz"                                  | false
         "38826"  | "Dassow"                                 | false
         "38827"  | "Kalkhorst"                              | false
-        "38828"  | "Schönberg Mecklenburg"                  | true   // TODO: ITU "Schönberg" only, but BNetzA "Schönberg Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
+        "38828"  | "Schönberg Mecklenburg"                  | true   // TODO: ITU "Schönberg" only, but BNetzA "Schönberg Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
         "3883"   | "Hagenow"                                | false
         "38841"  | "Neuhaus Elbe"                           | false
         "38842"  | "Lüttenmark"                             | false
@@ -1718,7 +1718,7 @@ class PhoneNumberOfflineGeocoderTest extends Specification {
         "38847"  | "Boizenburg Elbe"                        | false
         "38848"  | "Vellahn"                                | false
         "38850"  | "Gammelin"                               | false
-        "38851"  | "Zarrentin Mecklenburg"                  | true   // TODO: ITU "Zarrentin" only, but BNetzA "Zarrentin Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
+        "38851"  | "Zarrentin Mecklenburg"                  | true   // TODO: ITU "Zarrentin" only, but BNetzA "Zarrentin Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
         "38852"  | "Wittenburg"                             | false
         "38853"  | "Drönnewitz bei Hagenow"                 | false
         "38854"  | "Redefin"                                | false
@@ -1912,7 +1912,7 @@ class PhoneNumberOfflineGeocoderTest extends Specification {
         "3949"   | "Oschersleben Bode"                      | false
         "395"    | "Neubrandenburg"                         | false
         "39600"  | "Zwiedorf"                               | false
-        "39601"  | "Friedland Mecklenburg"                  | true   // TODO: ITU "Friedland" only, but BNetzA "Friedland Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
+        "39601"  | "Friedland Mecklenburg"                  | true   // TODO: ITU "Friedland" only, but BNetzA "Friedland Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
         "39602"  | "Kleeth"                                 | false
         "39603"  | "Burg Stargard"                          | false
         "39604"  | "Wildberg bei Altentreptow"              | false
@@ -1927,7 +1927,7 @@ class PhoneNumberOfflineGeocoderTest extends Specification {
         "3965"   | "Burow bei Altentreptow"                 | false
         "3966"   | "Cölpin"                                 | false
         "3967"   | "Oertzenhof bei Strasburg"               | false
-        "3968"   | "Schönbeck Mecklenburg"                  | true   // TODO: ITU "Schönbeck" only, but BNetzA "Schönbeck Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
+        "3968"   | "Schönbeck Mecklenburg"                  | true   // TODO: ITU "Schönbeck" only, but BNetzA "Schönbeck Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
         "3969"   | "Siedenbollentin"                        | false
         "3971"   | "Anklam"                                 | false
         "39721"  | "Liepen bei Anklam"                      | false
@@ -1973,8 +1973,8 @@ class PhoneNumberOfflineGeocoderTest extends Specification {
         "39827"  | "Schwarz bei Neustrelitz"                | false
         "39828"  | "Wustrow Kreis Mecklenburg Strelitz"     | false
         "39829"  | "Blankenförde"                           | false
-        "39831"  | "Feldberg Mecklenburg"                   | true   // TODO: ITU "Feldberg" only, but BNetzA "Feldberg Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
-        "39832"  | "Wesenberg Mecklenburg"                  | true   // TODO: ITU "Wesenberg" only, but BNetzA "Wesenberg Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
+        "39831"  | "Feldberg Mecklenburg"                   | true   // TODO: ITU "Feldberg" only, but BNetzA "Feldberg Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
+        "39832"  | "Wesenberg Mecklenburg"                  | true   // TODO: ITU "Wesenberg" only, but BNetzA "Wesenberg Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
         "39833"  | "Mirow Kreis Neustrelitz"                | false
         "3984"   | "Prenzlau"                               | false
         "39851"  | "Göritz bei Prenzlau"                    | false
@@ -2018,7 +2018,7 @@ class PhoneNumberOfflineGeocoderTest extends Specification {
         "39952"  | "Grammentin"                             | false
         "39953"  | "Schwinkendorf"                          | false
         "39954"  | "Stavenhagen Reuterstadt"                | false
-        "39955"  | "Jürgenstorf Mecklenburg"                | true   // TODO: ITU "Jürgenstorf" only, but BNetzA "Jürgenstorf Meckl", which is short form of "Mecklenburg", it is not included in PhoneLibe data.
+        "39955"  | "Jürgenstorf Mecklenburg"                | true   // TODO: ITU "Jürgenstorf" only, but BNetzA "Jürgenstorf Meckl", which is short form of "Mecklenburg", it is not included in LibPhoneNumber data.
         "39956"  | "Neukalen"                               | false
         "39957"  | "Gielow"                                 | false
         "39959"  | "Dargun"                                 | false

--- a/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberUtilTest.groovy
+++ b/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberUtilTest.groovy
@@ -45,13 +45,13 @@ class PhoneNumberUtilTest extends Specification {
         then: "is number expected: $expectedResult"
         if (result != expectedResult) {
             if (expectingFail) {
-                logger.info("PhoneLib is still not correctly normalizing $number to $expectedResult for region $regionCode, by giving $result")
+                logger.info("LibPhoneNumber is still not correctly normalizing $number to $expectedResult for region $regionCode, by giving $result")
             } else {
-                logger.warning("PhoneLib is suddenly not correctly normalizing $number to $expectedResult for region $regionCode, by giving $result")
+                logger.warning("LibPhoneNumber is suddenly not correctly normalizing $number to $expectedResult for region $regionCode, by giving $result")
             }
         } else {
             if (expectingFail) {
-                logger.info("!!! PhoneLib is now correctly normalizing $number to $expectedResult for region $regionCode !!!")
+                logger.info("!!! LibPhoneNumber is now correctly normalizing $number to $expectedResult for region $regionCode !!!")
             }
         }
 
@@ -88,13 +88,13 @@ class PhoneNumberUtilTest extends Specification {
         then: "is number expected: $expectedResult"
         if (result != expectedResult) {
             if (expectingFail) {
-                logger.info("PhoneLib is still not correctly validating $number to $expectedResult for region $regionCode, by giving $result")
+                logger.info("LibPhoneNumber is still not correctly validating $number to $expectedResult for region $regionCode, by giving $result")
             } else {
-                logger.warning("PhoneLib is suddenly not correctly validating $number to $expectedResult for region $regionCode, by giving $result")
+                logger.warning("LibPhoneNumber is suddenly not correctly validating $number to $expectedResult for region $regionCode, by giving $result")
             }
         } else {
             if (expectingFail) {
-                logger.info("!!! PhoneLib is now correctly validating $number to $expectedResult for region $regionCode !!!")
+                logger.info("!!! LibPhoneNumber is now correctly validating $number to $expectedResult for region $regionCode !!!")
             }
         }
 

--- a/src/test/groovy/de/telekom/phonenumbernormalizer/numberplans/PhoneLibWrapperTest.groovy
+++ b/src/test/groovy/de/telekom/phonenumbernormalizer/numberplans/PhoneLibWrapperTest.groovy
@@ -65,17 +65,17 @@ class PhoneLibWrapperTest extends Specification {
             "00"            | "DE"       | "TOO_SHORT_AFTER_IDD" // because IDC in Germany is 00
             "00"            | "US"       | "00"
             "00"            | "IT"       | "TOO_SHORT_AFTER_IDD" // because IDC in Italy is 00
-            //shorter zero check - just current PhoneLib behavior
+            //shorter zero check - just current LibPhoneNumber behavior
             "0"            | "AU"       | "NOT_A_NUMBER" // because its to short
             "0"            | "DE"       | "NOT_A_NUMBER" // because its to short
             "0"            | "US"       | "NOT_A_NUMBER" // because its to short
             "0"            | "IT"       | "NOT_A_NUMBER" // because its to short
-            //shorter 1 check - just current PhoneLib behavior
+            //shorter 1 check - just current LibPhoneNumber behavior
             "1"            | "AU"       | "NOT_A_NUMBER" // because its to short
             "1"            | "DE"       | "NOT_A_NUMBER" // because its to short
             "1"            | "US"       | "NOT_A_NUMBER" // because its to short
             "1"            | "IT"       | "NOT_A_NUMBER" // because its to short
-            //shorter zero check - just current PhoneLib behavior
+            //shorter zero check - just current LibPhoneNumber behavior
             "01"           | "AU"       | "01"
             "01"           | "DE"       | "01"
             "01"           | "US"       | "01"


### PR DESCRIPTION
- Upgrading used Java Version from 11 to 17 (as required for version jump of org.springframework to 6.x)
- Updating Dependencies to newer versions (all but surefire plugin keeps in 2.x since 3.x has vulnerability)
- Upgrading used Groovy Version for testing from 3 to 4
- Colloquial wording "PhoneLib" is replaced by Google's library name LibPhoneNumber