### PR TITLE
Use PhoneLib 8.13.48 and prepare release

### DIFF
--- a/REPORTED_ISSUES.md
+++ b/REPORTED_ISSUES.md
@@ -55,3 +55,6 @@ Google [fixed](https://github.com/google/libphonenumber/pull/3473/files#diff-db8
 Previous to Version 8.13.43 any German number within the range 17x was identified valid for both length 10 & 11. Now the 11 length case (176) is differentiated, that 176 is not validated valid with 10 digits. But 170-175, 177-179 is still validated valid for both length, but should be only valid with length of 10.
 
 Google stated it is aware and will bring changes after investigation that users are not unblock.
+
+Google [fixed](https://github.com/google/libphonenumber/pull/3671/files#diff-5061a7d3c54ba589aacce00dcee1ce92e098c40034749bcae4c8a4780bb40233) it with [8.13.48](https://github.com/google/libphonenumber/pull/3671) on 16.10.2024
+While normal mobile numbers are now aligend, voicemail numbers length is still problematic (BUG needs to be reported!).

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>normalizer</artifactId>
     <name>Phonenumber Normalizer</name>
     <description>Library to work with phonenumbers, especially to fix googles PhoneLib ignoring German Landline specifics.</description>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
     <url>https://github.com/telekom/phonenumber-normalizer</url>
 
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.googlecode.libphonenumber</groupId>
             <artifactId>libphonenumber</artifactId>
-            <version>8.13.47</version>
+            <version>8.13.48</version>
         </dependency>
 
         <dependency>
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>com.googlecode.libphonenumber</groupId>
             <artifactId>geocoder</artifactId>
-            <version>2.241</version>
+            <version>2.242</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -425,7 +425,7 @@
         <repository>
             <id>ossrh</id>
             <name>Central Repository OSSRH</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 </project>

--- a/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberUtil/IsValidNumberTest.groovy
+++ b/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberUtil/IsValidNumberTest.groovy
@@ -1678,140 +1678,140 @@ class IsValidNumberTest extends Specification {
         //
         // 0170
         //
-        "01700"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017010"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017011"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017012"         | "DE" | [false, false, true,  false, false, false, true,  false]
+        "01700"          | "DE" | [false, false, false, false, false, false, false, false]
+        "017010"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017011"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017012"         | "DE" | [false, false, false, false, false, false, false, false]
         // 017013 is reserved for voicemail - see tests below
-        "017014"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017015"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017016"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017017"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017018"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017019"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01702"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01703"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01704"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01705"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01706"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01707"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01708"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01709"          | "DE" | [false, false, true,  false, false, false, true,  false]
+        "017014"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017015"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017016"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017017"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017018"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017019"         | "DE" | [false, false, false, false, false, false, false, false]
+        "01702"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01703"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01704"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01705"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01706"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01707"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01708"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01709"          | "DE" | [false, false, false, false, false, false, false, false]
 
         //
         // 0171
         //
-        "01710"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017110"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017111"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017112"         | "DE" | [false, false, true,  false, false, false, true,  false]
+        "01710"          | "DE" | [false, false, false, false, false, false, false, false]
+        "017110"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017111"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017112"         | "DE" | [false, false, false, false, false, false, false, false]
         // 017113 is reserved for voicemail - see tests below
-        "017114"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017115"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017116"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017117"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017118"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017119"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01712"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01713"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01714"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01715"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01716"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01717"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01718"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01719"          | "DE" | [false, false, true,  false, false, false, true,  false]
+        "017114"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017115"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017116"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017117"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017118"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017119"         | "DE" | [false, false, false, false, false, false, false, false]
+        "01712"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01713"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01714"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01715"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01716"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01717"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01718"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01719"          | "DE" | [false, false, false, false, false, false, false, false]
 
         //
         // 0172
         //
-        "01720"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01721"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01722"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01723"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01724"          | "DE" | [false, false, true,  false, false, false, true,  false]
+        "01720"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01721"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01722"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01723"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01724"          | "DE" | [false, false, false, false, false, false, false, false]
         // 017250 is reserved for voicemail - see tests below
-        "017251"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017252"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017253"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017254"         | "DE" | [false, false, true,  false, false, false, true,  false]
+        "017251"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017252"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017253"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017254"         | "DE" | [false, false, false, false, false, false, false, false]
         // 017255 is reserved for voicemail - see tests below
-        "017256"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017257"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017258"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017259"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01726"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01727"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01728"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01729"          | "DE" | [false, false, true,  false, false, false, true,  false]
+        "017256"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017257"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017258"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017259"         | "DE" | [false, false, false, false, false, false, false, false]
+        "01726"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01727"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01728"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01729"          | "DE" | [false, false, false, false, false, false, false, false]
 
         //
         // 0173
         //
-        "01730"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01731"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01732"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01733"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01734"          | "DE" | [false, false, true,  false, false, false, true,  false]
+        "01730"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01731"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01732"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01733"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01734"          | "DE" | [false, false, false, false, false, false, false, false]
         // 017350 is reserved for voicemail - see tests below
-        "017351"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017352"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017353"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017354"         | "DE" | [false, false, true,  false, false, false, true,  false]
+        "017351"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017352"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017353"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017354"         | "DE" | [false, false, false, false, false, false, false, false]
         // 017355 is reserved for voicemail - see tests below
-        "017356"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017357"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017358"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017359"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01736"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01737"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01738"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01739"          | "DE" | [false, false, true,  false, false, false, true,  false]
+        "017356"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017357"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017358"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017359"         | "DE" | [false, false, false, false, false, false, false, false]
+        "01736"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01737"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01738"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01739"          | "DE" | [false, false, false, false, false, false, false, false]
 
         //
         // 0174
         //
-        "01740"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01741"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01742"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01743"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01744"          | "DE" | [false, false, true,  false, false, false, true,  false]
+        "01740"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01741"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01742"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01743"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01744"          | "DE" | [false, false, false, false, false, false, false, false]
         // 017450 is reserved for voicemail - see tests below
-        "017451"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017452"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017453"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017454"         | "DE" | [false, false, true,  false, false, false, true,  false]
+        "017451"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017452"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017453"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017454"         | "DE" | [false, false, false, false, false, false, false, false]
         // 017455 is reserved for voicemail - see tests below
-        "017456"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017457"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017458"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017459"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01746"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01747"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01748"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01749"          | "DE" | [false, false, true,  false, false, false, true,  false]
+        "017456"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017457"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017458"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017459"         | "DE" | [false, false, false, false, false, false, false, false]
+        "01746"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01747"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01748"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01749"          | "DE" | [false, false, false, false, false, false, false, false]
 
         //
         // 0175
         //
-        "01750"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017510"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017511"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017512"         | "DE" | [false, false, true,  false, false, false, true,  false]
+        "01750"          | "DE" | [false, false, false, false, false, false, false, false]
+        "017510"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017511"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017512"         | "DE" | [false, false, false, false, false, false, false, false]
         // 017513 is reserved for voicemail - see tests below
-        "017514"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017515"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017516"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017517"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017518"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017519"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01752"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01753"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01754"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01755"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01756"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01757"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01758"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01759"          | "DE" | [false, false, true,  false, false, false, true,  false]
+        "017514"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017515"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017516"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017517"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017518"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017519"         | "DE" | [false, false, false, false, false, false, false, false]
+        "01752"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01753"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01754"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01755"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01756"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01757"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01758"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01759"          | "DE" | [false, false, false, false, false, false, false, false]
 
         //
         // 0176
@@ -1839,71 +1839,71 @@ class IsValidNumberTest extends Specification {
         //
         // 0177
         //
-        "01770"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01771"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01772"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01773"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01774"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01775"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01776"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01777"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01778"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017790"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017791"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017792"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017793"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017794"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017795"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017796"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017797"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017798"         | "DE" | [false, false, true,  false, false, false, true,  false]
+        "01770"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01771"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01772"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01773"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01774"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01775"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01776"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01777"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01778"          | "DE" | [false, false, false, false, false, false, false, false]
+        "017790"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017791"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017792"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017793"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017794"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017795"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017796"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017797"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017798"         | "DE" | [false, false, false, false, false, false, false, false]
         // 017799 is reserved for voicemail - see tests below
 
         //
         // 0178
         //
-        "01780"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01781"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01782"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01783"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01784"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01785"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01786"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01787"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01788"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017890"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017891"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017892"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017893"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017894"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017895"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017896"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017897"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017898"         | "DE" | [false, false, true,  false, false, false, true,  false]
+        "01780"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01781"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01782"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01783"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01784"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01785"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01786"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01787"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01788"          | "DE" | [false, false, false, false, false, false, false, false]
+        "017890"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017891"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017892"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017893"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017894"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017895"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017896"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017897"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017898"         | "DE" | [false, false, false, false, false, false, false, false]
         // 017899 is reserved for voicemail - see tests below
 
         //
         // 0179
         //
-        "01790"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01791"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01792"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017930"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017931"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017932"         | "DE" | [false, false, true,  false, false, false, true,  false]
+        "01790"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01791"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01792"          | "DE" | [false, false, false, false, false, false, false, false]
+        "017930"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017931"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017932"         | "DE" | [false, false, false, false, false, false, false, false]
         // 017933 is reserved for voicemail - see tests below
-        "017934"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017935"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017936"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017937"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017938"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "017939"         | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01794"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01795"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01796"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01797"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01798"          | "DE" | [false, false, true,  false, false, false, true,  false]
-        "01799"          | "DE" | [false, false, true,  false, false, false, true,  false]
+        "017934"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017935"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017936"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017937"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017938"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017939"         | "DE" | [false, false, false, false, false, false, false, false]
+        "01794"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01795"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01796"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01797"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01798"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01799"          | "DE" | [false, false, false, false, false, false, false, false]
     }
 
     def "check if original lib fixed isValid for German Mobile 17 range with voicemail infix"(String numberUntilInfix, regionCode, boolean[] expectingFails) {
@@ -1917,8 +1917,18 @@ class IsValidNumberTest extends Specification {
                                   numberUntilInfix + "99999999",
                                   numberUntilInfix + "999999999"]
 
-        Boolean[] expectedResults = [false, true, true, false,
-                                     false, true, true, false]
+        Boolean[] expectedResults;
+
+        // https://www.bundesnetzagentur.de/DE/Fachthemen/Telekommunikation/Nummerierung/MobileDienste/LaengeRufnummernbloecke/start.html
+        // x: 6 length 8 otherwise 7
+        if (numberUntilInfix.startsWith("0176")) {
+            expectedResults = [false, false, true, false,
+                               false, false, true, false]
+        }
+
+       expectedResults = [false, true, false, false,
+                          false, true, false, false]
+
 
         when:
         Boolean[] results = []
@@ -1936,51 +1946,51 @@ class IsValidNumberTest extends Specification {
         numberUntilInfix | regionCode | expectingFails
         // see https://www.bundesnetzagentur.de/DE/Fachthemen/Telekommunikation/Nummerierung/MobileDienste/start.html
         // especially https://www.bundesnetzagentur.de/SharedDocs/Downloads/DE/Sachgebiete/Telekommunikation/Unternehmen_Institutionen/Nummerierung/Rufnummern/Mobile%20Dienste/Nummernplan-2018-03-02.pdf?__blob=publicationFile&v=1
-        // 017xyyyyyyy(y) x = block code, yyyyyyy(y) variable line lenx of 7 - 8 digits
+        // 017xyyyyyyy(y) x = block code, yyyyyyy(y) variable line len of 7 - 8 digits denping on x=6
 
         //
         // 0170
         //
-        "017013"         | "DE" | [true, false, false, false, true, false, false, false]
+        "017013"         | "DE" | [false, false, true, false, false, false, true, false]
         //
         // 0171
         //
-        "017113"         | "DE" | [true, false, false, false, true, false, false, false]
+        "017113"         | "DE" | [false, false, true, false, false, false, true, false]
         //
         // 0172
         //
-        "017250"         | "DE" | [true, true, true, false, true, true, true, false]
-        "017255"         | "DE" | [true, false,false, false, true, false, false, false]
+        "017250"         | "DE" | [false, true, false, false, false, true, false, false]
+        "017255"         | "DE" | [false, false, true, false, false, false, true, false]
         //
         // 0173
         //
-        "017350"         | "DE" | [true, true, true, false, true, true, true, false]
-        "017355"         | "DE" | [true, false, false, false, true, false, false, false]
+        "017350"         | "DE" | [false, true, false, false, false, true, false, false]
+        "017355"         | "DE" | [false, false, true, false, false, false, true, false]
         //
         // 0174
         //
-        "017450"         | "DE" | [true, true, true, false, true, true, true, false]
-        "017455"         | "DE" | [true, false, false, false, true, false, false, false]
+        "017450"         | "DE" | [false, true, false, false, false, true, false, false]
+        "017455"         | "DE" | [false, false, true, false, false, false, true, false]
         //
         // 0175
         //
-        "017513"         | "DE" | [true, false, false, false, true, false, false, false]
+        "017513"         | "DE" | [false, false, true, false, false, false, true, false]
         //
         // 0176
         //
-        "017633"         | "DE" | [true, false, false, false, true, false, false, false]
+        "017633"         | "DE" | [true, false, true, false, true, false, true, false]
         //
         // 0177
         //
-        "017799"         | "DE" | [true, false, false, false, true, false, false, false]
+        "017799"         | "DE" | [false, false, true, false, false, false, true, false]
         //
         // 0178
         //
-        "017899"         | "DE" | [true, false, false, false, true, false, false, false]
+        "017899"         | "DE" | [false, false, true, false, false, false, true, false]
         //
         // 0179
         //
-        "017933"         | "DE" | [true, false, false, false, true, false, false, false]
+        "017933"         | "DE" | [false, false, true, false, false, false, true, false]
     }
 
     def "check if original lib fixed isValid for German ServiceNumbers 180 range"(String reserve, regionCode, boolean[] expectingFails) {


### PR DESCRIPTION
Additionally:
- Fixing 17(0-5&7-9) length validation: Adapting Tests
- Change in Problems identifying mobile length 17x+Infix for VoiceMail: Adapting Tests