### PR TITLE
New Major Version 2.0.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 With the phonenumber-normalizer library, you can normalize phone numbers to the E164 format and national format, taking into account the specific complexities of the German number plan. The library can also differentiate between short numbers and those with NDCs and NACs, and can be useful for handling phone numbers in fixed-line contexts.
 
-While Google's [PhoneLib](https://github.com/google/libphonenumber) is a general-purpose library for handling phone numbers worldwide, phonenumber-normalizer a wrapper around it, which is specifically tailored to handle the complexities of the German number plan. Especially, phonenumber-normalizer can differentiate between short numbers and those with NDCs and NACs. When PhoneLib is not able to make this distinction, our wrapping corrects the result.
+While [Google's LibPhoneNumber](https://github.com/google/libphonenumber) is a general-purpose library for handling phone numbers worldwide, phonenumber-normalizer a wrapper around it, which is specifically tailored to handle the complexities of the German number plan. Especially, phonenumber-normalizer can differentiate between short numbers and those with NDCs and NACs. When PhoneLib is not able to make this distinction, our wrapping corrects the result.
 
 ![Phone Number Normalizer](https://user-images.githubusercontent.com/3244965/235174029-e58fab4c-37e9-49ba-834e-067b50082abb.png)
 
 ## Problem Statement(s)
 
-If you have to deal with the complexity of telephone numbers your natural choice of handling it, should be the great [PhoneLib](https://github.com/google/libphonenumber) of [Google](https://opensource.google).
+If you have to deal with the complexity of telephone numbers your natural choice of handling it, should be the great [LibPhoneNumber](https://github.com/google/libphonenumber) of [Google](https://opensource.google).
 
 That's what we did for some projects.
 And when we found bugs, we [returned that as feedback](./REPORTED_ISSUES.md) in good open-source tradition.
@@ -62,10 +62,10 @@ Additionally, we want to normalize a number with a default NDC, because we might
 ### Root Cause
 
 We think the problem arises from the following situation:
-- PhoneLib is storing the National Significant Number (NSN) as the number, which is the combination of NDC + SN.
-- PhoneLib is storing the number as uint64 which does not allow to store (a) leading Zero(s)
-- PhoneLib is storing leading Zeros in hasNumberOfLeadingZeros and getNumberOfLeadingZeros
-- PhoneLib checks "IS_POSSIBLE_LOCAL_ONLY" only by comparing the length of a number, which might work in a fix length number plan like the North American Number plan, but not with variable number length and optional NDC as in Germany.
+- Google's LibPhoneNumber is storing the National Significant Number (NSN) as the number, which is the combination of NDC + SN.
+- Google's LibPhoneNumber is storing the number as uint64 which does not allow to store (a) leading Zero(s)
+- Google's LibPhoneNumber is storing leading Zeros in hasNumberOfLeadingZeros and getNumberOfLeadingZeros
+- Google's LibPhoneNumber checks "IS_POSSIBLE_LOCAL_ONLY" only by comparing the length of a number, which might work in a fix length number plan like the North American Number plan, but not with variable number length and optional NDC as in Germany.
 
 What needs to be done:
 - Checking if the Country is supporting optional NDC
@@ -75,13 +75,13 @@ What needs to be done:
 - if that all applies, such an input needs to be treated as a short number and not be changed for E164 or National format (see short number [normalization of 116116](https://libphonenumber.appspot.com/phonenumberparser?number=116116&country=DE))
 
 The problem has been addressed but rejected like with [issue tracker 180311606](https://issuetracker.google.com/issues/180311606).
-Reasons are either PhoneLib just make best efforts for formatting and not format checking or that they focus on mobile context while most problems happens in fixed-line context.
+Reasons are either Google's LibPhoneNumber just make best efforts for formatting and not format checking or that they focus on mobile context while most problems happens in fixed-line context.
 
 ## State of Our Implementation
 
 ### Code
 
-As a wrapper we did not change any code of PhoneLib itself, so an [upgrade to the newest version should be possible by just updating the version in the dependency POM definition](UPDATE_FOR_NEW_PHONELIB.md).
+As a wrapper we did not change any code of Google's LibPhoneNumber itself, so an [upgrade to the newest version should be possible by just updating the version in the dependency POM definition](UPDATE_FOR_NEW_PHONELIB.md).
 
 You could either take the sourcecode directly from the repository or use Maven dependency management by adding:
 ```
@@ -117,35 +117,35 @@ Now we get a E164 formatted number, because now we know, how which NDC has to be
 
 ### Use Of Reflection
 
-To check if a number plan of a country is using an optional NDC and NAC, we need to get the countries region metadata from PhoneLib.
+To check if a number plan of a country is using an optional NDC and NAC, we need to get the countries region metadata from Google's LibPhoneNumber.
 
 With getMetadataForRegion there is a method on the PhoneNumberUtil class, but it is not public.
 
 So we are forced to [use reflection and override its accessibility](https://github.com/telekom/phonenumber-normalizer/blob/main/src/main/java/de/telekom/phonenumbernormalizer/numberplans/PhoneLibWrapper.java#L280).
 
 If you are using AOT (ahead of time) compiler, you need to take care of this.
-(While it is used indirectly with the normal PhoneLib use of the wrapper, it might not be safe for all AOT compilers).
+(While it is used indirectly with the normal Google's LibPhoneNumber use of the wrapper, it might not be safe for all AOT compilers).
 
 ### Use of Own ShortNumber Recognition
 
-When we started with the wrapper, PhoneLib did not recognize some phone assistant services as short numbers.
+When we started with the wrapper, Google's LibPhoneNumber did not recognize some phone assistant services as short numbers.
 This as been fixed by [issue tracker 182490059](https://issuetracker.google.com/u/1/issues/182490059). 
 
-But for the EU Social Service Number Range 116xxx, PhoneLib is only checking the assigned number 116116 in Germany.
+But for the EU Social Service Number Range 116xxx, Google's LibPhoneNumber is only checking the assigned number 116116 in Germany.
 This is in contradiction to normal validation, where the range is checked and assignment checks are explicitly not in scope.
 But for the [issue 183669955](https://issuetracker.google.com/u/1/issues/183669955), they insist on assignment, since they need it for free call checks.
-But for other EU states PhoneLib is using the full raneg (e.g. [CZ](https://github.com/google/libphonenumber/blob/4c532d93587d2f9d16dc7a536df55bf179158210/resources/ShortNumberMetadata.xml#L3342))
+But for other EU states Google's LibPhoneNumber is using the full range (e.g. [CZ](https://github.com/google/libphonenumber/blob/4c532d93587d2f9d16dc7a536df55bf179158210/resources/ShortNumberMetadata.xml#L3342))
 
 ### One More Thing: Area Gecode Label
 
 There is a table of names for the area code from the BNetzA, which is using non-common abbreviations, which wouldn't be understood by end users.
-But PhoneLib is using those and refusing the long transcription, because they only trust the BNetzA document (see [issue tracker 183383466](https://issuetracker.google.com/issues/183383466)).
+But Google's LibPhoneNumber is using those and refusing the long transcription, because they only trust the BNetzA document (see [issue tracker 183383466](https://issuetracker.google.com/issues/183383466)).
 In addition, the BNetzA has published a [document on the ITU](https://www.itu.int/dms_pub/itu-t/oth/02/02/T02020000510006PDFE.pdf) and [its own website](https://www.bundesnetzagentur.de/SharedDocs/Downloads/DE/Sachgebiete/Telekommunikation/Unternehmen_Institutionen/Nummerierung/Rufnummern/ONRufnr/Vorwahlverzeichnis_ONB.zip.zip?__blob=publicationFile&v=298), which differ for some values, too.
 
 We provide resolution for each country but also for cities in Germany and states in the US.
 Our engine is using easy to generate [JSON data](./src/main/resources/arealabels/nationallabels/), so you could also provide your own resolution.
 
-We only rely on the number analysis / formation logic of PhoneLib.
+We only rely on the number analysis / formation logic of Google's LibPhoneNumber.
 Their GeoCoder is not used for your labeling.
 We only use the PhoneLib's GeoCoder in some testcases, to check if ours and their labeling against each other. 
 

--- a/REPORTED_ISSUES.md
+++ b/REPORTED_ISSUES.md
@@ -15,7 +15,7 @@ This issue has been resolved.
 
 ### 2021-03-25 - [Germany (DE, +49): 116xxx Short Number valid vs. assigned](https://issuetracker.google.com/issues/183669955)
 
-This issue pertains to the EU-wide special social number short code definition. Although the regulation clearly defines a range, PhoneLib is not validating against that range, but against a list of currently assigned/operated numbers. At least for the German number space, as mentioned in the initial issue discussion (see first one above), the library is only partly or even completely checking the whole range in other EU number spaces.
+This issue pertains to the EU-wide special social number short code definition. Although the regulation clearly defines a range, Google's LibPhoneNumber is not validating against that range, but against a list of currently assigned/operated numbers. At least for the German number space, as mentioned in the initial issue discussion (see first one above), the library is only partly or even completely checking the whole range in other EU number spaces.
 
 On the one hand, the [FAQ](https://github.com/google/libphonenumber/blob/master/FAQ.md#what_is_valid)(https://github.com/google/libphonenumber/blob/master/FAQ.md) states that “valid” does not mean “numbers are currently assigned to a specific user and reachable.”
 On the other hand, it states that “a valid number range is one from which numbers can be freely assigned by carriers to users,” which is not the case for EU-wide numbers that require special clearance.
@@ -24,8 +24,8 @@ While it seems that the last point is the argument for rejecting the issue (whic
 
 ## Internal Implementation
 
-After a long discussion and closing the issues as stated above, we decided to implement a minimal fix for normalizing German Phonenumbers for our internal use, to support the phoning capability of Deutsche Telekom Smart Speaker.
-We also set up [test cases to verify if PhoneLib behavior changes to correctly normalize the currently failing cases](https://github.com/telekom/phonenumber-normalizer/blob/main/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberUtilTest.groovy), so that our implementation would become unnecessary.
+After a long discussion and closing the issues as stated above, we decided to implement a minimal fix for normalizing German phone numbers for our internal use, to support the phoning capability of Deutsche Telekom Smart Speaker.
+We also set up [test cases to verify if Google's LibPhoneNumber behavior changes to correctly normalize the currently failing cases](https://github.com/telekom/phonenumber-normalizer/blob/main/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberUtilTest.groovy), so that our implementation would become unnecessary.
 
 We also discovered, during its development, that the geolocation method uses BenetzA given labels, which include abbreviations.
 [For a smart speaker, we needed a “speakable” label - so we created the following issue and added our own list to our interim solution](https://github.com/telekom/phonenumber-normalizer/blob/main/src/main/resources/arealabels/nationallabels/de.json).

--- a/UPDATE_FOR_NEW_PHONELIB.md
+++ b/UPDATE_FOR_NEW_PHONELIB.md
@@ -1,10 +1,10 @@
 # How to adapt to a new Version of PhoneLib
 
-If Google updates its [PhoneLib](https://github.com/google/libphonenumber), this project should be updated to use that new version. This file is a step by step instruction how to do this:
+If Google updates its [LibPhoneNumber](https://github.com/google/libphonenumber), this project should be updated to use that new version. This file is a step by step instruction how to do this:
 
 1. Create a new local branch - best name it ```phonelib/X_YY_ZZ``` so it is easily seen that this branch is just an update for the version X.YY.ZZ, without any new features.
 
-2. Update [pom.xml](pom.xml) to use the new phonelib version:
+2. Update [pom.xml](pom.xml) to use the new Google's LibPhoneNumber version:
    ```
    <dependency>
      <groupId>com.googlecode.libphonenumber</groupId>
@@ -25,7 +25,7 @@ If Google updates its [PhoneLib](https://github.com/google/libphonenumber), this
         </dependency>
    ```
    
-5. Run all unit test and check log messages if Phonelib still is not correctly:
+5. Run all unit test and check log messages if Google's LibPhoneNumber still is not correctly:
    a) normalizing specific number -> this project is still necessary
    b) labeling specific numbers -> own area labels for DE still necessary
    if there are corrections or additional mismatches listed - name those in the commit message and update tests.
@@ -34,16 +34,16 @@ If Google updates its [PhoneLib](https://github.com/google/libphonenumber), this
 
 7. Commit & Push the Snapshot with a message like:
    ```
-   Use PhoneLib X.YY.ZZ and prepare release
+   Use Google's LibPhoneNumber X.YY.ZZ and prepare release
    ```
    
 8. Go to Github and create a pull request for the branch.
 
 9. Wait until pull request passed all checks - merge or ask a maintainer to merge the pull request into main.
 
-10. After merge has finished, draft a new Release. Use as tag the ```v```+ the version number of the pom, where you removed ```-SNAPSHOT```. As Release title use  ```PhoneLib X.YY.ZZ``` and add a message like:
+10. After merge has finished, draft a new Release. Use as tag the ```v```+ the version number of the pom, where you removed ```-SNAPSHOT```. As Release title use  ```Google's LibPhoneNumber X.YY.ZZ``` and add a message like:
     ```
-    Use the latest PhoneLib version from four days ago.
+    Use Google's latest LibPhoneNumber version from four days ago.
     ```
     Keep the flag "Set as the latest release" and press Publish release.
 
@@ -62,4 +62,4 @@ If Google updates its [PhoneLib](https://github.com/google/libphonenumber), this
 
 16. Delete the branch ```phonelib/X_YY_ZZ```.
 
-Congratulation! You have updated the project to the [current PhoneLib version](https://central.sonatype.com/artifact/com.googlecode.libphonenumber/libphonenumber).
+Congratulation! You have updated the project to Google'S [current LibPhoneNumber version](https://central.sonatype.com/artifact/com.googlecode.libphonenumber/libphonenumber).

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>de.telekom.phonenumber</groupId>
     <artifactId>normalizer</artifactId>
     <name>Phonenumber Normalizer</name>
-    <description>Library to work with phone numbers, especially to fix Google's LibPhoneNumber ignoring German Landline specifics.</description>
+    <description>Library to wrap around Google's LibPhoneNumber library, to fix the ignoring of German Landline specifics when normalizing phone numbers.</description>
     <version>2.0.0</version>
     <packaging>jar</packaging>
     <url>https://github.com/telekom/phonenumber-normalizer</url>
@@ -67,8 +67,25 @@
         <rootDir>${project.basedir}/..</rootDir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <mapstruct.version>1.3.0.Final</mapstruct.version>
-        <lombok.version>1.18.28</lombok.version>
+        <!-- Used Versions of Google's libphone project -->
+        <libphonenumber.version>9.0.0</libphonenumber.version>
+        <geocoder.version>3.0</geocoder.version>
+        <!-- Used Versions of other dependencies: -->
+        <java.version>17</java.version>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <lombok.version>1.18.30</lombok.version>
+        <surefire.plugin.version>2.22.2</surefire.plugin.version> <!-- not yet updated because version 3.x has vulnerability-->
+        <com.fasterxml.jackson.core.version>2.18.0</com.fasterxml.jackson.core.version>
+        <org.codehaus.gmavenplus.version>1.11.0</org.codehaus.gmavenplus.version>
+        <org.springframework.version>6.1.14</org.springframework.version>
+        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
+        <org.apache.commons.version>3.17.0</org.apache.commons.version>
+        <io.swagger.verion>1.6.14</io.swagger.verion>
+        <org.slf4j.version>2.0.16</org.slf4j.version>
+        <jakarta.annotation.version>3.0.0-M1</jakarta.annotation.version>
+        <org.apache.groovy.version>4.0.18</org.apache.groovy.version>
+        <org.junit.platform.version>1.10.1</org.junit.platform.version>
+        <org.spockframework.version>2.4-M1-groovy-4.0</org.spockframework.version>
         <!-- JaCoCo & SonarQube -->
         <rootDir>${project.basedir}</rootDir>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -77,7 +94,6 @@
         <sonar.coverage.jacoco.xmlReportPaths>
             ${project.basedir}/../${aggregate.report.dir}
         </sonar.coverage.jacoco.xmlReportPaths>
-        <surefire.plugin.version>2.22.2</surefire.plugin.version>
     </properties>
 
     <dependencies>
@@ -86,7 +102,7 @@
         <dependency>
             <groupId>com.googlecode.libphonenumber</groupId>
             <artifactId>libphonenumber</artifactId>
-            <version>9.0.0</version>
+            <version>${libphonenumber.version}</version>
         </dependency>
 
         <dependency>
@@ -95,48 +111,45 @@
             <scope>provided</scope> <!-- must be provided, see docs -->
             <version>${lombok.version}</version>
         </dependency>
-        <!--
-        TODO: need to upgrade spring context to 6.x
-        -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>5.3.39</version>
+            <version>${org.springframework.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.17.0</version>
+            <version>${org.apache.commons.version}</version>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>1.6.14</version>
+            <version>${io.swagger.verion}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.18.0</version>
+            <version>${com.fasterxml.jackson.core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.18.0</version>
+            <version>${com.fasterxml.jackson.core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.0</version>
+            <version>${com.fasterxml.jackson.core.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.16</version>
+            <version>${org.slf4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${jakarta.annotation.version}</version>
         </dependency>
         <!-- For Testing only -->
         <!--
@@ -150,47 +163,26 @@
         <dependency>
             <groupId>com.googlecode.libphonenumber</groupId>
             <artifactId>geocoder</artifactId>
-            <version>3.0</version>
+            <version>${geocoder.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>3.0.22</version>
+            <version>${org.apache.groovy.version}</version>
             <scope>test</scope>
             <type>pom</type>
-            <exclusions>
-                <exclusion>
-                    <!-- Used Version 7.5 has https://devhub.checkmarx.com/cve-details/CVE-2022-4065/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea&utm_term=maven -->
-                    <groupId>org.testng</groupId>
-                    <artifactId>testng</artifactId>
-                </exclusion>
-                <exclusion>
-                    <!--User Version 3.5.1 has https://devhub.checkmarx.com/cve-details/CVE-2007-2379/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea -->
-                    <groupId>org.webjars</groupId>
-                    <artifactId>jquery</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>${org.junit.platform.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>2.4-M4-groovy-3.0</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- Replace Version 7.5 which has https://devhub.checkmarx.com/cve-details/CVE-2022-4065/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea&utm_term=maven -->
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>7.10.2</version>
-            <scope>test</scope>
-        </dependency>
-        <!--Replaces Version 3.5.1 which has https://devhub.checkmarx.com/cve-details/CVE-2007-2379/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea -->
-        <!--Not using Version 3.7.1 which has other vulnerabilities -->
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>jquery</artifactId>
-            <version>3.7.0</version>
+            <version>${org.spockframework.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -227,7 +219,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>${maven.compiler.plugin.version}</version>
             </plugin>
 
             <plugin>
@@ -245,7 +237,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.11.0</version>
+                <version>${org.codehaus.gmavenplus.version}</version>
             </plugin>
 
             <plugin>
@@ -353,10 +345,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>${maven.compiler.plugin.version}</version>
                     <configuration>
-                        <release>11</release>
-
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
                         <annotationProcessorPaths>
                             <!-- be aware of the order in regards to -->
                             <!-- https://github.com/rzwitserloot/lombok/issues/1538 -->
@@ -406,7 +398,7 @@
                 <plugin>
                     <groupId>org.codehaus.gmavenplus</groupId>
                     <artifactId>gmavenplus-plugin</artifactId>
-                    <version>1.11.0</version>
+                    <version>${org.codehaus.gmavenplus.version}</version>
                     <executions>
                         <execution>
                             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
     <groupId>de.telekom.phonenumber</groupId>
     <artifactId>normalizer</artifactId>
     <name>Phonenumber Normalizer</name>
-    <description>Library to work with phonenumbers, especially to fix googles PhoneLib ignoring German Landline specifics.</description>
-    <version>1.3.8-SNAPSHOT</version>
+    <description>Library to work with phone numbers, especially to fix Google's LibPhoneNumber ignoring German Landline specifics.</description>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
     <url>https://github.com/telekom/phonenumber-normalizer</url>
 
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.googlecode.libphonenumber</groupId>
             <artifactId>libphonenumber</artifactId>
-            <version>8.13.55</version>
+            <version>9.0.0</version>
         </dependency>
 
         <dependency>
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>com.googlecode.libphonenumber</groupId>
             <artifactId>geocoder</artifactId>
-            <version>2.249</version>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberAreaLabel.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberAreaLabel.java
@@ -23,12 +23,10 @@ import java.util.Optional;
  */
 public interface PhoneNumberAreaLabel {
 
-
-
     /**
-     * Get a location name for a E164 formated number
+     * Get a location name for a E164 formatted number
      *
-     * @param e164number number following E164 schema eg. +4961511234567
+     * @param e164number number following E164 schema e.g. +4961511234567
      * @return nullable optional with either a national label or if non is available a country label
      */
     Optional<String> getLocationByE164Number(String e164number);

--- a/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberAreaLabelImpl.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberAreaLabelImpl.java
@@ -32,7 +32,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.stereotype.Component;
 
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.util.*;
 import java.util.regex.Pattern;

--- a/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberAreaLabelImpl.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberAreaLabelImpl.java
@@ -43,7 +43,7 @@ import java.util.regex.Pattern;
  *     <li>Country Calling Code to German Country Names</li>
  *     <li>AU-NDC: "Weihnachtsinsel" &amp; "Kokosinseln"</li>
  *     <li>DE-NDC: German City-Names replacing formal abbreviation with long name</li>
- *     <li>RU-NDC: Country seperation "Russland" &amp; "Kasachstan"</li>
+ *     <li>RU-NDC: Country separation "Russland" &amp; "Kasachstan"</li>
  *     <li>US-NDC: For US and CA just the state names</li>
  * </ul>
  */

--- a/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberNormalizer.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberNormalizer.java
@@ -34,7 +34,7 @@ public interface PhoneNumberNormalizer {
     void setFallbackRegionCode(String fallBackRegionCode);
 
     /**
-     * Normalizes the number using PhoneLib with some additions to compensate.
+     * Normalizes the number using Google's LibPhoneNumber with some additions to compensate.
      * <p>
      * Preferable to {@link PhoneNumberNormalizer#normalizePhoneNumber(String, String)}, because default NDC can be provided, so that more compensation for generating a valid E164 can be done.
      * </p>
@@ -47,7 +47,7 @@ public interface PhoneNumberNormalizer {
     String normalizePhoneNumber(String number, DeviceContext deviceContext);
 
     /**
-     * Normalizes the number using PhoneLib with some additions to compensate.
+     * Normalizes the number using Google's LibPhoneNumber with some additions to compensate.
      * <p>
      * Not as powerful as {@link PhoneNumberNormalizer#normalizePhoneNumber(String, DeviceContext)}, because no default NDC can be set.
      * </p>

--- a/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberNormalizerImpl.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberNormalizerImpl.java
@@ -71,14 +71,14 @@ public class PhoneNumberNormalizerImpl implements PhoneNumberNormalizer {
     }
 
     /**
-     * Uses wrapper of PhoneLib to identify if special rules apply for normalization.<br/>
+     * Uses wrapper of Google's LibPhoneNumber to identify if special rules apply for normalization.<br/>
      * Using device context for enriching the number make it normalizable to E164 format if NDC is optional in the used number plan, but not used in the phone number to be normalized.
-     * @param wrapper instanced wrapper of PhoneLib
+     * @param wrapper instanced wrapper of Google's LibPhoneNumber
      * @param deviceContext information like CC, NDC and {@link de.telekom.phonenumbernormalizer.dto.DeviceContextLineType} from which the number is dialled
      * @return E164 formatted phone number or dialable version of it or null
      */
     private String normalize(PhoneLibWrapper wrapper, DeviceContext deviceContext) {
-        // international prefix has been added by PhoneLib even if it's not valid in the number plan.
+        // international prefix has been added by Google's LibPhoneNumber even if it's not valid in the number plan.
         if (wrapper == null) {
             LOGGER.debug("PhoneLipWrapper was not initialized");
             return null;

--- a/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberNormalizerImpl.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/PhoneNumberNormalizerImpl.java
@@ -99,10 +99,10 @@ public class PhoneNumberNormalizerImpl implements PhoneNumberNormalizer {
         }
 
         if (wrapper.hasRegionNationalAccessCode() && deviceContext != null) {
-            //Number plan is using a NationalPrefix aka Trunc Code ... so we could add Area Code if not included in the number.
+            //Number plan is using a NationalPrefix aka Trunk Code ... so we could add Area Code if not included in the number.
             return wrapper.extendNumberByDefaultAreaCodeAndCountryCode(wrapper.getNationalAccessCode(), deviceContext.getNationalDestinationCode());
         }
-        // Number plan is not using NationalPrefix aka Trunc Code ... its also not a short number, so country code can be added:
+        // Number plan is not using NationalPrefix aka Trunk Code ... its also not a short number, so country code can be added:
         return wrapper.getE164Formatted();
     }
 
@@ -120,7 +120,7 @@ public class PhoneNumberNormalizerImpl implements PhoneNumberNormalizer {
         }
 
         // international prefix is added by the lib even if it's not valid in the number plan.
-        //checking if the input number is equal to the nationalNumber based on number plan and trunc code logic.
+        //checking if the input number is equal to the nationalNumber based on number plan and trunk code logic.
         boolean hasNoCCAndNoNAC = wrapper.hasNoCountryCodeNorNationalAccessCode();
 
         LOGGER.debug("Number has no CC and no NAC: {}.", hasNoCCAndNoNAC);

--- a/src/main/java/de/telekom/phonenumbernormalizer/dto/DeviceContext.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/dto/DeviceContext.java
@@ -54,7 +54,7 @@ public interface DeviceContext {
 
     /**
      * Getter for the Country (Calling) Code of the countries number plan, where the device is originated.
-     * Without international dialing prefix nor trunc code. If not known or not set, it should return DeviceContext.UNKNOWN_VALUE.
+     * Without international dialing prefix nor trunk code. If not known or not set, it should return DeviceContext.UNKNOWN_VALUE.
      * <p>
      * E.G. "49" for Germany
      * </p>
@@ -67,7 +67,7 @@ public interface DeviceContext {
 
     /**
      * Setter for the Country (Calling) Code of the countries number plan, where the device is originated.
-     * Without international deailing prefix nor trunc code. If not known it should be set to DeviceContext.UNKNOWN_VALUE.
+     * Without international dealing prefix nor trunk code. If not known it should be set to DeviceContext.UNKNOWN_VALUE.
      * <p>
      * E.G. "49" for Germany
      * </p>
@@ -80,7 +80,7 @@ public interface DeviceContext {
 
     /**
      * Getter for the National Destination Code (NDC) of the countries number plan, where the device is originated.
-     * Without National Access Code (NAC) nor trunc code. If not known or not set, it should return DeviceContext.UNKNOWN_VALUE.
+     * Without National Access Code (NAC) nor trunk code. If not known or not set, it should return DeviceContext.UNKNOWN_VALUE.
      * <p>
      * E.G. "228" for Bonn in Germany where the Deutsche Telekom Headquarter is located
      * </p>
@@ -93,7 +93,7 @@ public interface DeviceContext {
 
     /**
      * Setter for the National Destination Code (NDC) of the countries number plan, where the device is originated.
-     * Without National Access Code (NAC) nor trunc code. If not known it should be set to DeviceContext.UNKNOWN_VALUE.
+     * Without National Access Code (NAC) nor trunk code. If not known it should be set to DeviceContext.UNKNOWN_VALUE.
      * <p>
      * E.G. "228" for Bonn in Germany where the Deutsche Telekom Headquarter is located
      * </p>

--- a/src/main/java/de/telekom/phonenumbernormalizer/dto/DeviceContextDto.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/dto/DeviceContextDto.java
@@ -46,7 +46,7 @@ public class DeviceContextDto implements DeviceContext {
 
     /**
      * The Country (Calling) Code of the countries number plan, where the device is originated. Also known as Landesvorwahl.
-     * Without international dialing prefix nor trunc code. If not known or not set, it should return DeviceContext.UNKNOWN_VALUE.
+     * Without international dialing prefix nor trunk code. If not known or not set, it should return DeviceContext.UNKNOWN_VALUE.
      * <p/>
      * E.G. "49" for Germany
      *
@@ -57,13 +57,13 @@ public class DeviceContextDto implements DeviceContext {
 
     /**
      * The National Destination Code (NDC) of the countries number plan, where the device is originated. Also known as AreaCode, ONKZ or (Orts-)Vorwahl.
-     * Without National Access Code (NAC) nor trunc code. If not known or not set, it should return DeviceContext.UNKNOWN_VALUE.
+     * Without National Access Code (NAC) nor trunk code. If not known or not set, it should return DeviceContext.UNKNOWN_VALUE.
      * <p/>
      * E.G. "228" for Bonn in Germany where the Deutsche Telekom Headquarter is located
      *
      * @see DeviceContext#UNKNOWN_VALUE
      */
-    @ApiModelProperty(value = "National Destination Code without leading 0 nor other trunc codes; if not present its unknown", example = "228")
+    @ApiModelProperty(value = "National Destination Code without leading 0 nor other trunk codes; if not present its unknown", example = "228")
     private String nationalDestinationCode = DeviceContext.UNKNOWN_VALUE;
 
 }

--- a/src/main/java/de/telekom/phonenumbernormalizer/numberplans/NumberPlan.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/numberplans/NumberPlan.java
@@ -46,8 +46,8 @@ public abstract class NumberPlan {
      * The key (String) is representing a prefix for the number and the value (Integer) is the total length of the short code (including the prefix)
      * <ul>
      * <li>e.g. "110"; 3 - the total length is already the length of the prefix, so its exactly the short number</li>
-     * <li>e.g. "1100"; 5 - the total length is longer than the length of the prefix, so all number from 11000 to 11009 are coverd</li>
-     * <li>e.g. both rules above can be combined, because longer prefixes are evaluated first, so that partical ranges of rules with shorter prefix can be overriden.</li>
+     * <li>e.g. "1100"; 5 - the total length is longer than the length of the prefix, so all number from 11000 to 11009 are covered</li>
+     * <li>e.g. both rules above can be combined, because longer prefixes are evaluated first, so that partial ranges of rules with shorter prefix can be overridden.</li>
      * </ul>
      * @return Map of rules for the short codes
      *

--- a/src/main/java/de/telekom/phonenumbernormalizer/numberplans/NumberPlan.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/numberplans/NumberPlan.java
@@ -29,7 +29,7 @@ import java.util.Comparator;
  * This class provides basic logic to check a given number against a simple set of rules to identify if it is short numbers, which does not need normalization.
  * It also needs to provide its country calling code, to specify where the rules apply.
  * <p>
- * PhoneLib already provide a ShortNumbers, but for EU wide 116xxx range only a few countries are configured to support the range. 
+ * Google's LibPhoneNumber already provide a ShortNumbers, but for EU wide 116xxx range only a few countries are configured to support the range.
  * For Germany only currently assigned numbers are configured which is in contrast to Googles definition of checks, 
  * but nevertheless the <a href="https://issuetracker.google.com/u/1/issues/183669955">corresponding Issues</a> has been rejected.
  * </p><p>

--- a/src/main/java/de/telekom/phonenumbernormalizer/numberplans/PhoneLibWrapper.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/numberplans/PhoneLibWrapper.java
@@ -191,7 +191,7 @@ public class PhoneLibWrapper {
      * so we could permanently add a default NDC and NAC to the given number and for this new value the method directly return a E164 formatted representation.
      * @param nationalAccessCode the NAC to be added e.g. for Germany it would be "0"
      * @param defaultNationalDestinationCode the NDC to be added depending on the use telephone line origination.
-     * @return if possible a E164 formatted representation or just the diallable representation of the given number.
+     * @return if possible a E164 formatted representation or just the dialable representation of the given number.
      *
      * @see PhoneLibWrapper#PhoneLibWrapper(String, String)
      */
@@ -218,7 +218,7 @@ public class PhoneLibWrapper {
     }
 
     /**
-     * Some Special dial-able characters make a number either not necessary to be normalized ("+" is already normalized) or can't be normalized ("*" control codes)
+     * Some Special dialable characters make a number either not necessary to be normalized ("+" is already normalized) or can't be normalized ("*" control codes)
      * @param value phone number representation
      * @return if phone number starts with special characters which makes normalization unable / not necessary
      */
@@ -311,7 +311,7 @@ public class PhoneLibWrapper {
             return null;
         }
         StringBuilder nationalNumber = new StringBuilder(Long.toString(phoneNumber.getNationalNumber()));
-        // if-clause necessary, because getNumberOfLeadingZeros is always 1 for a possible trunc code and special 0 in Italy
+        // if-clause necessary, because getNumberOfLeadingZeros is always 1 for a possible trunk code and special 0 in Italy
         if (phoneNumber.hasNumberOfLeadingZeros() || phoneNumber.hasItalianLeadingZero())
             for (int i = 0; i < phoneNumber.getNumberOfLeadingZeros(); i++) {
                 nationalNumber.insert(0, "0");

--- a/src/main/java/de/telekom/phonenumbernormalizer/numberplans/PhoneLibWrapper.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/numberplans/PhoneLibWrapper.java
@@ -26,11 +26,11 @@ import java.lang.reflect.Method;
 import java.util.Objects;
 
 /**
- * Wrapper around the PhoneLib library from Google
+ * Wrapper around Google's LibPhoneNumber library
  * <p>
  * Using reflection to access internal information to know if a region has a nation prefix &amp; which one it is.
  * </p><p>
- * Providing own NumberPlans logic as an alternative to PhoneLib ShortNumber.
+ * Providing own NumberPlans logic as an alternative to Google's LibPhoneNumber ShortNumber.
  * </p>
  * @see NumberPlan
  */
@@ -48,7 +48,7 @@ public class PhoneLibWrapper {
     String dialableNumber;
 
     /**
-     * The given number normalized with PhoneLib, risking we get a incorrect normalization
+     * The given number normalized with Google's LibPhoneNumber, risking we get an incorrect normalization
      *
      * @see PhoneLibWrapper#PhoneLibWrapper(String, String)
      * @see PhoneLibWrapper#isNormalizingTried()
@@ -65,24 +65,24 @@ public class PhoneLibWrapper {
     String regionCode;
 
     /**
-     * The number plan metadata which PhoneLib is using for the given region code.
+     * The number plan metadata which Google's LibPhoneNumber is using for the given region code.
      *
      * @see PhoneLibWrapper#PhoneLibWrapper(String, String)
      */
     Phonemetadata.PhoneMetadata metadata;
 
     /**
-     * An instance of the PhoneLib short number utility.
+     * An instance of Google's LibPhoneNumber short number utility.
      */
     private static final ShortNumberInfo shortNumberUtil = ShortNumberInfo.getInstance();
 
     /**
-     * An instance of the PhoneLib number utility.
+     * An instance of Google's LibPhoneNumber number utility.
      */
     private static final PhoneNumberUtil phoneUtil = PhoneNumberUtil.getInstance();
 
     /**
-     * Storing if PhoneLib has been used to parse the given number into semiNormalizedNumber.
+     * Storing if Google's LibPhoneNumber has been used to parse the given number into semiNormalizedNumber.
      *
      * @see PhoneLibWrapper#PhoneLibWrapper(String, String)
      * @see PhoneLibWrapper#semiNormalizedNumber

--- a/src/main/java/de/telekom/phonenumbernormalizer/numberplans/PhoneNumberValidationResult.java
+++ b/src/main/java/de/telekom/phonenumbernormalizer/numberplans/PhoneNumberValidationResult.java
@@ -18,9 +18,9 @@ package de.telekom.phonenumbernormalizer.numberplans;
 import com.google.i18n.phonenumbers.PhoneNumberUtil.ValidationResult;
 
 /**
- * Wrapper around the PhoneLib enum {@link ValidationResult} from Google
+ * Wrapper around Google's LibPhoneNumber enum {@link ValidationResult} from Google
  * <p>
- * When the PhoneLib is validating a phone number it returns a value of the enum {@link ValidationResult}.
+ * When Google's LibPhoneNumber is validating a phone number it returns a value of the enum {@link ValidationResult}.
  * </p><p>
  * It differentiates two possible positive and five possible negative results. The value
  * {@link ValidationResult#INVALID_LENGTH} is for any negative case, which is not explicitly covered by any of the other

--- a/src/test/groovy/de/telekom/phonenumbernormalizer/PhoneNumberNormalizerImplTest.groovy
+++ b/src/test/groovy/de/telekom/phonenumbernormalizer/PhoneNumberNormalizerImplTest.groovy
@@ -18,9 +18,6 @@ package de.telekom.phonenumbernormalizer
 import de.telekom.phonenumbernormalizer.dto.DeviceContext
 import de.telekom.phonenumbernormalizer.dto.DeviceContextDto
 import de.telekom.phonenumbernormalizer.dto.DeviceContextLineType
-import de.telekom.phonenumbernormalizer.numberplans.PhoneLibWrapper
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import spock.lang.Specification
 
 

--- a/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberOfflineGeocoderTest.groovy
+++ b/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberOfflineGeocoderTest.groovy
@@ -50,14 +50,14 @@ class PhoneNumberOfflineGeocoderTest extends Specification {
         if ((result != expectedResult) && (result2 != expectedResult)){
             if (expectingFail) {
                 if (!LOGONLYUNEXPECTED) {
-                    logger.info("PhoneLib is still not correctly labeling $areacode to $expectedResult by giving $result")
+                    logger.info("LibPhoneNumber is still not correctly labeling $areacode to $expectedResult by giving $result")
                 }
             } else {
-                logger.warning("PhoneLib is suddenly not correctly labeling $areacode to $expectedResult by giving $result")
+                logger.warning("LibPhoneNumber is suddenly not correctly labeling $areacode to $expectedResult by giving $result")
             }
         } else {
             if (expectingFail) {
-                logger.info("!!! PhoneLib is now correctly labeling $areacode to $expectedResult !!!")
+                logger.info("!!! LibPhoneNumber is now correctly labeling $areacode to $expectedResult !!!")
             }
         }
 

--- a/src/test/groovy/de/telekom/phonenumbernormalizer/numberplans/PhoneLibWrapperTest.groovy
+++ b/src/test/groovy/de/telekom/phonenumbernormalizer/numberplans/PhoneLibWrapperTest.groovy
@@ -65,17 +65,17 @@ class PhoneLibWrapperTest extends Specification {
             "00"            | "DE"       | "TOO_SHORT_AFTER_IDD" // because IDC in Germany is 00
             "00"            | "US"       | "00"
             "00"            | "IT"       | "TOO_SHORT_AFTER_IDD" // because IDC in Italy is 00
-            //shorter zero check - just current PhoneLib behavior
+            //shorter zero check - just current Google's LibPhoneNumber behavior
             "0"            | "AU"       | "NOT_A_NUMBER" // because its to short
             "0"            | "DE"       | "NOT_A_NUMBER" // because its to short
             "0"            | "US"       | "NOT_A_NUMBER" // because its to short
             "0"            | "IT"       | "NOT_A_NUMBER" // because its to short
-            //shorter 1 check - just current PhoneLib behavior
+            //shorter 1 check - just current Google's LibPhoneNumber behavior
             "1"            | "AU"       | "NOT_A_NUMBER" // because its to short
             "1"            | "DE"       | "NOT_A_NUMBER" // because its to short
             "1"            | "US"       | "NOT_A_NUMBER" // because its to short
             "1"            | "IT"       | "NOT_A_NUMBER" // because its to short
-            //shorter zero check - just current PhoneLib behavior
+            //shorter zero check - just current Google's LibPhoneNumber behavior
             "01"           | "AU"       | "01"
             "01"           | "DE"       | "01"
             "01"           | "US"       | "01"

--- a/src/test/groovy/de/telekom/phonenumbernormalizer/numberplans/PhoneLibWrapperTest.groovy
+++ b/src/test/groovy/de/telekom/phonenumbernormalizer/numberplans/PhoneLibWrapperTest.groovy
@@ -17,7 +17,6 @@ package de.telekom.phonenumbernormalizer.numberplans
 
 import com.google.i18n.phonenumbers.PhoneNumberUtil
 import com.google.i18n.phonenumbers.NumberParseException
-import com.google.i18n.phonenumbers.Phonenumber
 import spock.lang.Specification
 
 


### PR DESCRIPTION
Upgrading to Google's libPhoneNumber 9.0.0

Upgrading used Java Version from 11 to 17 (at least 15 for new libPhoneNumber. Upgrade to major version 6 of spring boot - to avoid vulnerability, requires 17)

Upgrading groovy version from 3 to 4

Colloquial wording "PhoneLib" is replaced by Google's library name LibPhoneNumber and making some typo fixes in documentation, too.