### PR TITLE
Use Google's LibPhoneNumber 9.0.7 and prepare release

### DIFF
--- a/REPORTED_ISSUES.md
+++ b/REPORTED_ISSUES.md
@@ -60,4 +60,8 @@ Google [fixed](https://github.com/google/libphonenumber/pull/3671/files#diff-506
 While normal mobile numbers are now aligend, voicemail numbers length is still problematic (BUG needs to be reported!).
 
 ### 2024-12-14 - [Metadata Update of 8.13.52 for DE mobile 176 range is invalid](https://issuetracker.google.com/issues/384186540)
-While Google had corrected mobile 17x range with prior feedback, they introduced an inconsistency with the last DE meta data update.
+While Google had corrected mobile 17x range with prior feedback, they introduced an inconsistency with the last DE meta data update, allowing also 10 length number while only 11 are valid.
+They do not want to change it, because they user are blocked with historical shorter numbers (but no prove found that those really exists)
+
+### 2025-06-15 - [Metadata Update of 9.0.7 for DE mobile 172 range is invalide](https://issuetracker.google.com/issues/425121215)
+Similar to previously change of 176, Google change mobile 172 introduced an inconsistency with the last DE meta data update, allowing also 11 length number while only 10 are valid.

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <artifactId>normalizer</artifactId>
     <name>Phonenumber Normalizer</name>
     <description>Library to wrap around Google's LibPhoneNumber library, to fix the ignoring of German Landline specifics when normalizing phone numbers.</description>
-    <version>2.0.6-SNAPSHOT</version>
+    <version>2.0.6</version>
     <packaging>jar</packaging>
     <url>https://github.com/telekom/phonenumber-normalizer</url>
 
@@ -68,8 +68,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Used Versions of Google's libphone project -->
-        <libphonenumber.version>9.0.6</libphonenumber.version>
-        <geocoder.version>3.6</geocoder.version>
+        <libphonenumber.version>9.0.7</libphonenumber.version>
+        <geocoder.version>3.7</geocoder.version>
         <!-- Used Versions of other dependencies: -->
         <java.version>17</java.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>

--- a/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberUtil/IsValidNumberTest.groovy
+++ b/src/test/groovy/de/telekom/phonenumbernormalizer/extern/libphonenumber/PhoneNumberUtil/IsValidNumberTest.groovy
@@ -1724,25 +1724,25 @@ class IsValidNumberTest extends Specification {
         //
         // 0172
         //
-        "01720"          | "DE" | [false, false, false, false, false, false, false, false]
-        "01721"          | "DE" | [false, false, false, false, false, false, false, false]
-        "01722"          | "DE" | [false, false, false, false, false, false, false, false]
-        "01723"          | "DE" | [false, false, false, false, false, false, false, false]
-        "01724"          | "DE" | [false, false, false, false, false, false, false, false]
+        "01720"          | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "01721"          | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "01722"          | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "01723"          | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "01724"          | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
         // 017250 is reserved for voicemail - see tests below
-        "017251"         | "DE" | [false, false, false, false, false, false, false, false]
-        "017252"         | "DE" | [false, false, false, false, false, false, false, false]
-        "017253"         | "DE" | [false, false, false, false, false, false, false, false]
-        "017254"         | "DE" | [false, false, false, false, false, false, false, false]
+        "017251"         | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "017252"         | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "017253"         | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "017254"         | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
         // 017255 is reserved for voicemail - see tests below
-        "017256"         | "DE" | [false, false, false, false, false, false, false, false]
-        "017257"         | "DE" | [false, false, false, false, false, false, false, false]
-        "017258"         | "DE" | [false, false, false, false, false, false, false, false]
-        "017259"         | "DE" | [false, false, false, false, false, false, false, false]
-        "01726"          | "DE" | [false, false, false, false, false, false, false, false]
-        "01727"          | "DE" | [false, false, false, false, false, false, false, false]
-        "01728"          | "DE" | [false, false, false, false, false, false, false, false]
-        "01729"          | "DE" | [false, false, false, false, false, false, false, false]
+        "017256"         | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "017257"         | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "017258"         | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "017259"         | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "01726"          | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "01727"          | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "01728"          | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
+        "01729"          | "DE" | [false, false, true, false, false, false, true, false] // see https://issuetracker.google.com/issues/425121215
 
         //
         // 0173
@@ -1959,8 +1959,8 @@ class IsValidNumberTest extends Specification {
         //
         // 0172
         //
-        "017250"         | "DE" | [false, true, false, false, false, true, false, false]
-        "017255"         | "DE" | [false, false, true, false, false, false, true, false]
+        "017250"         | "DE" | [true, true, false, false, true, true, false, false] // see https://issuetracker.google.com/issues/425121215 at least for a few true
+        "017255"         | "DE" | [true, false, true, false, true, false, true, false] // see https://issuetracker.google.com/issues/425121215 at least for a few true
         //
         // 0173
         //


### PR DESCRIPTION
This version of Google LibPhone introduces a meta data bug for DE mobile range 172 which is limited to length of 10, but now also validates a length of 11. This is reported by https://issuetracker.google.com/issues/425121215